### PR TITLE
v3.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: php
 php:
   - 7.0
-  - 5.6
+  - 5.6.6
 
 before_script:
+  - sleep 10
   - travis_retry composer self-update
   - travis_retry composer install --prefer-source --no-interaction --dev
 
 script: vendor/phpunit/phpunit/phpunit --verbose
+
+services:
+  - elasticsearch
+

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -66,6 +66,9 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
                             ['match_phrase' => ['foo' => 1]]
                         ]
                     ]
+                ],
+                'sort' => [
+                    ['id' => 'desc']
                 ]
             ]
         ]);
@@ -73,6 +76,7 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
         $engine = new ElasticsearchEngine($client, 'scout');
         $builder = new Laravel\Scout\Builder(new ElasticsearchEngineTestModel, 'zonda');
         $builder->where('foo', 1);
+        $builder->orderBy('id', 'desc');
         $engine->search($builder);
     }
 


### PR DESCRIPTION
- bumping to php 5.6.6 (Earliest version that can support php elasticsearch)
- `within`method is now being taken into account when specified by the search builder #31
- Now if the record is not found on the db will not throw undefined offset #36
- Implemented orderBy #46