### PR TITLE
Update ElasticsearchProvider.php

### DIFF
--- a/src/ElasticsearchProvider.php
+++ b/src/ElasticsearchProvider.php
@@ -13,7 +13,7 @@ class ElasticsearchProvider extends ServiceProvider
      */
     public function boot()
     {
-        resolve(EngineManager::class)->extend('elasticsearch', function($app) {
+        app(EngineManager::class)->extend('elasticsearch', function($app) {
             return new ElasticsearchEngine(ElasticBuilder::create()
                 ->setHosts(config('scout.elasticsearch.hosts'))
                 ->build(),


### PR DESCRIPTION
use `app` instead of `resolve` to make lumen 5.4 compatible.

`app` and `resolve` are identical since 5.4, see https://github.com/laravel/framework/blob/5.4/src/Illuminate/Foundation/helpers.php#L690