### PR TITLE
Support for "WHERE IN" searches

### DIFF
--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -166,6 +166,10 @@ class ElasticsearchEngine extends Engine
     protected function filters(Builder $builder)
     {
         return collect($builder->wheres)->map(function ($value, $key) {
+            if (is_array($value)) {
+                return ['terms' => [$key => $value]];
+            }
+
             return ['match_phrase' => [$key => $value]];
         })->values()->all();
     }

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -63,7 +63,8 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
                     'bool' => [
                         'must' => [
                             ['query_string' => ['query' => '*zonda*']],
-                            ['match_phrase' => ['foo' => 1]]
+                            ['match_phrase' => ['foo' => 1]],
+                            ['terms' => ['bar' => [1, 3]]],
                         ]
                     ]
                 ],
@@ -76,6 +77,7 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
         $engine = new ElasticsearchEngine($client, 'scout');
         $builder = new Laravel\Scout\Builder(new ElasticsearchEngineTestModel, 'zonda');
         $builder->where('foo', 1);
+        $builder->where('bar', [1, 3]);
         $builder->orderBy('id', 'desc');
         $engine->search($builder);
     }


### PR DESCRIPTION
Right now - using this project as the driver - passing an array as $value to `Laravel\Scout\Builder->where()` results in: 
```
Elasticsearch\Common\Exceptions\ServerErrorResponseException with message '{"error":{"root_cause":[{"type":"illegal_state_exception","reason":"Can't get text on a START_ARRAY at 1:86"}],"type":"illegal_state_exception","reason":"Can't get text on a START_ARRAY at 1:86"},"status":500}'
```

http://stackoverflow.com/a/40737488/7362396 states that `match` doesn't work with arrays, so this PR simply applies the solution also proposed in the Stack Overflow question -> Use `terms` if the $value is an array.