### PR TITLE
Execute the callback that can be passed to the Builder

### DIFF
--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -154,6 +154,15 @@ class ElasticsearchEngine extends Engine
                 $options['numericFilters']);
         }
 
+        if ($builder->callback) {
+            return call_user_func(
+                $builder->callback,
+                $this->elastic,
+                $builder->query,
+                $params
+            );
+        }
+
         return $this->elastic->search($params);
     }
 

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -80,6 +80,28 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
         $engine->search($builder);
     }
 
+    public function test_builder_callback_can_manipulate_search_parameters_to_elasticsearch()
+    {
+        /** @var \Elasticsearch\Client|\Mockery\MockInterface $client */
+        $client = Mockery::mock(\Elasticsearch\Client::class);
+        $client->shouldReceive('search')->with('modified_by_callback');
+
+        $engine = new ElasticsearchEngine($client, 'scout');
+        $builder = new Laravel\Scout\Builder(
+            new ElasticsearchEngineTestModel(),
+            'huayra',
+            function (\Elasticsearch\Client $client, $query, $params) {
+                $this->assertNotEmpty($params);
+                $this->assertEquals('huayra', $query);
+                $params = 'modified_by_callback';
+
+                return $client->search($params);
+            }
+        );
+
+        $engine->search($builder);
+    }
+
     public function test_map_correctly_maps_results_to_models()
     {
         $client = Mockery::mock('Elasticsearch\Client');


### PR DESCRIPTION
Context/Reasoning: https://github.com/laravel/scout/pull/111

Right now [the callback you can pass](https://github.com/laravel/scout/blob/v3.0.3/src/Searchable.php#L86) is straight up ignored with this engine/driver.

This implementation is analogical to the official AlgoliaEngine implementation: https://github.com/laravel/scout/blob/v3.0.3/src/Engines/AlgoliaEngine.php#L112-L119