### PR TITLE
Added option of using a different index per model

### DIFF
--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -48,7 +48,6 @@ class ElasticsearchEngine extends Engine
         return ($this->perModelIndex ? $model->searchableAs() : $this->index);
     }
 
-
     /**
      * Update the given model in the index.
      *

--- a/src/ElasticsearchProvider.php
+++ b/src/ElasticsearchProvider.php
@@ -17,7 +17,8 @@ class ElasticsearchProvider extends ServiceProvider
             return new ElasticsearchEngine(ElasticBuilder::create()
                 ->setHosts(config('scout.elasticsearch.hosts'))
                 ->build(),
-                config('scout.elasticsearch.index')
+                config('scout.elasticsearch.index'),
+                config('scout.elasticsearch.perModelIndex', false)
             );
         });
     }


### PR DESCRIPTION
For our use-case we'd like to use different indexes for the models.  [Laravel's Scout documentation](https://laravel.com/docs/5.4/scout#configuration) has `searchableAs` as the function to override to set the index name.
> Typically, this is the plural form of the model name; however, you are free to customize the model's index by overriding the `searchableAs` method on the model:

This pull request provides a configuration option within config/scout.php to allow an index per model.  It is backward compliant so it will behave the same as before if the option isn't set.
```
// config/scout.php
    'elasticsearch' => [
        'index' => env('ELASTICSEARCH_INDEX', 'laravel'),
        'hosts' => [
            env('ELASTICSEARCH_HOST', 'http://localhost'),
        ],
        'perModelIndex' => true,
    ],
```
