### PR TITLE
chain `values` method in `map` function

### DIFF
--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -203,7 +203,7 @@ class ElasticsearchEngine extends Engine
 
         return collect($results['hits']['hits'])->map(function ($hit) use ($model, $models) {
             return isset($models[$hit['_id']]) ? $models[$hit['_id']] : null;
-        })->filter();
+        })->filter()->values();
     }
 
     /**


### PR DESCRIPTION
```php
collect($results['hits']['hits'])->map(function ($hit) use ($model, $models) {
    return isset($models[$hit['_id']]) ? $models[$hit['_id']] : null;
})->filter();
```
when using `paginate()` the returened data property would contains some null values which makes data to be an object rather than list.