### PR TITLE
Removed count function. Fixes #80

### DIFF
--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -210,7 +210,7 @@ class ElasticsearchEngine extends Engine
      */
     public function map($results, $model)
     {
-        if (count($results['hits']['total']) === 0) {
+        if ($results['hits']['total'] === 0) {
             return Collection::make();
         }
 


### PR DESCRIPTION
Related to #80. Since php 7.2, count a number will generate a warning. Because
$results['hits']['total'] is a number we can just compare it to zero.

`if ($results['hits']['total'] === 0)`