### PR TITLE
Add Elasticsearch 6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ After you've published the Laravel Scout package configuration:
 
 ...
     'elasticsearch' => [
-        'index' => env('ELASTICSEARCH_INDEX', 'laravel'),
+        'index-prefix' => env('ELASTICSEARCH_INDEX_PREFIX', 'laravel'),
         'hosts' => [
             env('ELASTICSEARCH_HOST', 'http://localhost'),
         ],

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=5.6.4",
         "laravel/scout": "^3.0",
-        "elasticsearch/elasticsearch": "^5.0"
+        "elasticsearch/elasticsearch": "^6.0"
     },
      "require-dev": {
         "fzaninotto/faker": "~1.4",
@@ -23,7 +23,7 @@
         }
     },
     "suggest": {
-        "elasticsearch/elasticsearch": "Required to use the Elasticsearch engine (^5.0)."
+        "elasticsearch/elasticsearch": "Required to use the Elasticsearch engine (^6.0)."
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=5.6.4",
         "laravel/scout": "^3.0",
-        "elasticsearch/elasticsearch": "^6.0"
+        "elasticsearch/elasticsearch": "^5.0"
     },
      "require-dev": {
         "fzaninotto/faker": "~1.4",
@@ -23,7 +23,7 @@
         }
     },
     "suggest": {
-        "elasticsearch/elasticsearch": "Required to use the Elasticsearch engine (^6.0)."
+        "elasticsearch/elasticsearch": "Required to use the Elasticsearch engine (^5.0)."
     },
     "extra": {
         "laravel": {

--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -24,7 +24,7 @@ class ElasticsearchEngine extends Engine
      */
     protected $elastic;
 
-    protected $type = 'doc';
+    protected $type = '_doc';
 
 
     /**

--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -15,7 +15,7 @@ class ElasticsearchEngine extends Engine
      *
      * @var string
      */
-    protected $index;
+    protected $indexPrefix;
     
     /**
      * Elastic where the instance of Elastic|\Elasticsearch\Client is stored.
@@ -24,16 +24,19 @@ class ElasticsearchEngine extends Engine
      */
     protected $elastic;
 
+    protected $type = 'doc';
+
+
     /**
      * Create a new engine instance.
      *
      * @param  \Elasticsearch\Client  $elastic
      * @return void
      */
-    public function __construct(Elastic $elastic, $index)
+    public function __construct(Elastic $elastic, $indexPrefix)
     {
         $this->elastic = $elastic;
-        $this->index = $index;
+        $this->indexPrefix = $indexPrefix;
     }
 
     /**
@@ -51,8 +54,8 @@ class ElasticsearchEngine extends Engine
             $params['body'][] = [
                 'update' => [
                     '_id' => $model->getKey(),
-                    '_index' => $this->index,
-                    '_type' => $model->searchableAs(),
+                    '_index' => $this->indexPrefix.$model->searchableAs(),
+                    '_type' => $this->type
                 ]
             ];
             $params['body'][] = [
@@ -79,8 +82,8 @@ class ElasticsearchEngine extends Engine
             $params['body'][] = [
                 'delete' => [
                     '_id' => $model->getKey(),
-                    '_index' => $this->index,
-                    '_type' => $model->searchableAs(),
+                    '_index' => $this->indexPrefix.$model->searchableAs(),
+                    '_type' => $this->type
                 ]
             ];
         });
@@ -133,8 +136,8 @@ class ElasticsearchEngine extends Engine
     protected function performSearch(Builder $builder, array $options = [])
     {
         $params = [
-            'index' => $this->index,
-            'type' => $builder->index ?: $builder->model->searchableAs(),
+            'index' => $this->indexPrefix.$builder->model->searchableAs(),
+            '_type' => $this->type,
             'body' => [
                 'query' => [
                     'bool' => [

--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -24,7 +24,7 @@ class ElasticsearchEngine extends Engine
      */
     protected $elastic;
 
-    protected $type = '_doc';
+    protected $type = 'doc';
 
 
     /**

--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -137,7 +137,7 @@ class ElasticsearchEngine extends Engine
     {
         $params = [
             'index' => $this->indexPrefix.$builder->model->searchableAs(),
-            '_type' => $this->type,
+            'type' => $this->type,
             'body' => [
                 'query' => [
                     'bool' => [

--- a/src/ElasticsearchProvider.php
+++ b/src/ElasticsearchProvider.php
@@ -17,7 +17,7 @@ class ElasticsearchProvider extends ServiceProvider
             return new ElasticsearchEngine(ElasticBuilder::create()
                 ->setHosts(config('scout.elasticsearch.hosts'))
                 ->build(),
-                config('scout.elasticsearch.index')
+                config('scout.elasticsearch.index-prefix')
             );
         });
     }

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -19,7 +19,7 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
                     'update' => [
                         '_id' => 1,
                         '_index' => 'scouttable',
-                        '_type' => '_doc',
+                        '_type' => 'doc',
                     ]
                 ],
                 [
@@ -42,7 +42,7 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
                     'delete' => [
                         '_id' => 1,
                         '_index' => 'scouttable',
-                        '_type' => '_doc',
+                        '_type' => 'doc',
                     ]
                 ],
             ]
@@ -57,7 +57,7 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
         $client = Mockery::mock('Elasticsearch\Client');
         $client->shouldReceive('search')->with([
             'index' => 'scouttable',
-            'type' => '_doc',
+            'type' => 'doc',
             'body' => [
                 'query' => [
                     'bool' => [

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -19,7 +19,7 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
                     'update' => [
                         '_id' => 1,
                         '_index' => 'scouttable',
-                        '_type' => 'doc',
+                        '_type' => '_doc',
                     ]
                 ],
                 [
@@ -42,7 +42,7 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
                     'delete' => [
                         '_id' => 1,
                         '_index' => 'scouttable',
-                        '_type' => 'doc',
+                        '_type' => '_doc',
                     ]
                 ],
             ]
@@ -57,7 +57,7 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
         $client = Mockery::mock('Elasticsearch\Client');
         $client->shouldReceive('search')->with([
             'index' => 'scouttable',
-            'type' => 'doc',
+            'type' => '_doc',
             'body' => [
                 'query' => [
                     'bool' => [

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -18,8 +18,8 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
                 [
                     'update' => [
                         '_id' => 1,
-                        '_index' => 'scout',
-                        '_type' => 'table',
+                        '_index' => 'scouttable',
+                        '_type' => 'doc',
                     ]
                 ],
                 [
@@ -41,8 +41,8 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
                 [
                     'delete' => [
                         '_id' => 1,
-                        '_index' => 'scout',
-                        '_type' => 'table',
+                        '_index' => 'scouttable',
+                        '_type' => 'doc',
                     ]
                 ],
             ]
@@ -56,8 +56,8 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
     {
         $client = Mockery::mock('Elasticsearch\Client');
         $client->shouldReceive('search')->with([
-            'index' => 'scout',
-            'type' => 'table',
+            'index' => 'scouttable',
+            'type' => 'doc',
             'body' => [
                 'query' => [
                     'bool' => [


### PR DESCRIPTION
Elastic.co [suggests some alternatives](https://www.elastic.co/guide/en/elasticsearch/reference/6.0/removal-of-types.html#_alternatives_to_mapping_types). I've decided to use one index per document type due to his scalability.
However, it breaks the compatibility of the current architecture and requires a major version release. 