### PR TITLE
Setting to disable query wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This package makes is the [Elasticsearch](https://www.elastic.co/products/elasti
 
 You can install the package via composer:
 
-``` bash
+```bash
 composer require tamayo/laravel-scout-elastic
 ```
 
@@ -32,6 +32,7 @@ You must add the Scout service provider and the package service provider in your
 ```
 
 ### Setting up Elasticsearch configuration
+
 You must have a Elasticsearch server up and running with the index you want to use created
 
 If you need help with this please refer to the [Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/index.html)
@@ -43,12 +44,13 @@ After you've published the Laravel Scout package configuration:
 // Set your driver to elasticsearch
     'driver' => env('SCOUT_DRIVER', 'elasticsearch'),
 
-...
+... // add after the algolia key
     'elasticsearch' => [
         'index' => env('ELASTICSEARCH_INDEX', 'laravel'),
         'hosts' => [
             env('ELASTICSEARCH_HOST', 'http://localhost'),
         ],
+        'wrap_query' => env('ELASTICSEARCH_WRAP_QUERY', true),
     ],
 ...
 ```
@@ -56,6 +58,7 @@ After you've published the Laravel Scout package configuration:
 ## Usage
 
 Now you can use Laravel Scout as described in the [official documentation](https://laravel.com/docs/5.3/scout)
+
 ## Credits
 
 - [Erick Tamayo](https://github.com/ericktamayo)

--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -25,15 +25,25 @@ class ElasticsearchEngine extends Engine
     protected $elastic;
 
     /**
+     * Setting to wrap the query sent to Elastic search
+     *
+     * @var bool
+     */
+    protected $wrapQuery = true;
+
+    /**
      * Create a new engine instance.
      *
      * @param  \Elasticsearch\Client  $elastic
+     * @param  string  $index
+     * @param  bool  $wrapQuery
      * @return void
      */
-    public function __construct(Elastic $elastic, $index)
+    public function __construct(Elastic $elastic, $index, $wrapQuery = true)
     {
         $this->elastic = $elastic;
         $this->index = $index;
+        $this->wrapQuery = $wrapQuery;
     }
 
     /**
@@ -132,13 +142,14 @@ class ElasticsearchEngine extends Engine
      */
     protected function performSearch(Builder $builder, array $options = [])
     {
+        $query = $this->wrapQuery ? "*{$builder->query}*" : $builder->query;
         $params = [
             'index' => $this->index,
             'type' => $builder->index ?: $builder->model->searchableAs(),
             'body' => [
                 'query' => [
                     'bool' => [
-                        'must' => [['query_string' => [ 'query' => "*{$builder->query}*"]]]
+                        'must' => [['query_string' => ['query' => $query]]]
                     ]
                 ]
             ]

--- a/src/ElasticsearchProvider.php
+++ b/src/ElasticsearchProvider.php
@@ -17,7 +17,8 @@ class ElasticsearchProvider extends ServiceProvider
             return new ElasticsearchEngine(ElasticBuilder::create()
                 ->setHosts(config('scout.elasticsearch.hosts'))
                 ->build(),
-                config('scout.elasticsearch.index')
+                config('scout.elasticsearch.index'),
+                config('scout.elasticsearch.wrap_query')
             );
         });
     }

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -82,6 +82,28 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
         $engine->search($builder);
     }
 
+    public function test_search_sends_correct_parameters_to_elasticsearch_not_wrapped()
+    {
+        $client = Mockery::mock(\Elasticsearch\Client::class);
+        $client->shouldReceive('search')->with([
+            'index' => 'scout',
+            'type' => 'table',
+            'body' => [
+                'query' => [
+                    'bool' => [
+                        'must' => [
+                            ['query_string' => ['query' => 'field:value anotherfield:value']],
+                        ]
+                    ]
+                ],
+            ]
+        ]);
+
+        $engine = new ElasticsearchEngine($client, 'scout', false);
+        $builder = new Laravel\Scout\Builder(new ElasticsearchEngineTestModel, 'field:value anotherfield:value');
+        $engine->search($builder);
+    }
+
     public function test_builder_callback_can_manipulate_search_parameters_to_elasticsearch()
     {
         /** @var \Elasticsearch\Client|\Mockery\MockInterface $client */


### PR DESCRIPTION
While I was implementing this into https://github.com/saelos/saelos, I noticed that the standard lucene query structure for Elastic search wasn't supported since this package wrapped the query sent to elastic search in `*`'s  for a wildcard search. 

This PR adds the ability to disable wrapping the query with a wildcard while preserving current functionality.

This fixes #96 

It should take precedence over and close #75 