### PR TITLE
Compatibility with Scout 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 php:
   - 7.0
-  - 5.6.6
 
 before_script:
   - sleep 10

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel", "scout", "elasticsearch", "elastic"],
     "require": {
         "php": ">=5.6.4",
-        "laravel/scout": "^3.0|^4.0",
+        "laravel/scout": "^5.0",
         "elasticsearch/elasticsearch": "^5.0"
     },
      "require-dev": {

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Database\Eloquent\Collection;
+use Laravel\Scout\Builder;
 use ScoutEngines\Elasticsearch\ElasticsearchEngine;
 
 class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
@@ -109,12 +110,13 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
         $client = Mockery::mock('Elasticsearch\Client');
         $engine = new ElasticsearchEngine($client, 'scout');
 
-        $model = Mockery::mock('Illuminate\Database\Eloquent\Model');
-        $model->shouldReceive('getKeyName')->andReturn('id');
-        $model->shouldReceive('whereIn')->once()->with('id', ['1'])->andReturn($model);
-        $model->shouldReceive('get')->once()->andReturn(Collection::make([new ElasticsearchEngineTestModel]));
+        $builder = Mockery::mock(Builder::class);
 
-        $results = $engine->map([
+        $model = Mockery::mock('Illuminate\Database\Eloquent\Model');
+        $model->shouldReceive('getScoutKey')->andReturn('1');
+        $model->shouldReceive('getScoutModelsByIds')->once()->with($builder, ['1'])->andReturn(Collection::make([$model]));
+
+        $results = $engine->map($builder, [
             'hits' => [
                 'total' => '1',
                 'hits' => [


### PR DESCRIPTION
In #99 it was possible to support both, v3 & v4 of Scout. Unfortunately, this is no longer possible for v5 due to a changed method signature.

I reviewed the changes in Scout 5 and figured the only thing that changed was that we now pass around another callback. This also made it necessary to use Scouts `getScoutModelsByIds` for something that was coded in this package until now (I think this is better, one less function we need to care about/test).

I adjusted the unit-tests to pass again. Also, I checked out this branch in one of my projects where I use this package, and tested querying, indexing, and deleting, with success.

I think this should be tagged MINOR (`3.1.0`), to leave room in `3.0.x` to backport fixes, but also allow Composer to automatically update it when Scout 5 is installed. Composer will not auto-update aslong as the user has a constraint on `laravel/scout:^4`. And if he upgrades Scout to 5 he has to deal with their breaking changes. I don't think there are any in this PR then.

I tried to keep it minimal, we can make other upgrades like the PHP-ES-Client in seperate PRs.