### PR TITLE
declared abstract method flush

### DIFF
--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -256,4 +256,14 @@ class ElasticsearchEngine extends Engine
             return [$order['column'] => $order['direction']];
         })->toArray();
     }
+
+    /**
+     * Flush all of the model's records from the engine.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function flush($model)
+    {
+    }
 }


### PR DESCRIPTION
fixed 'Class ScoutEngines\Elasticsearch\ElasticsearchEngine contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Laravel\Scout\Engines\Engine::flush)