### PR TITLE
Add support for Laravel Scout 6.0 and 7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["laravel", "scout", "elasticsearch", "elastic"],
     "require": {
         "php": ">=5.6.4",
-        "laravel/scout": "^5.0",
+        "laravel/scout": "^5.0|^6.0|^7.0",
         "elasticsearch/elasticsearch": "^5.0"
     },
      "require-dev": {

--- a/src/ElasticsearchEngine.php
+++ b/src/ElasticsearchEngine.php
@@ -6,7 +6,6 @@ use Laravel\Scout\Builder;
 use Laravel\Scout\Engines\Engine;
 use Elasticsearch\Client as Elastic;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Collection as BaseCollection;
 
 class ElasticsearchEngine extends Engine
 {
@@ -212,21 +211,16 @@ class ElasticsearchEngine extends Engine
     public function map(Builder $builder, $results, $model)
     {
         if ($results['hits']['total'] === 0) {
-            return Collection::make();
+            return $model->newCollection();
         }
 
-        $keys = collect($results['hits']['hits'])
-                        ->pluck('_id')->values()->all();
+        $keys = collect($results['hits']['hits'])->pluck('_id')->values()->all();
 
-        $models = $model->getScoutModelsByIds(
-            $builder, $keys
-        )->keyBy(function ($model) {
-            return $model->getScoutKey();
-        });
-
-        return collect($results['hits']['hits'])->map(function ($hit) use ($model, $models) {
-            return isset($models[$hit['_id']]) ? $models[$hit['_id']] : null;
-        })->filter()->values();
+        return $model->getScoutModelsByIds(
+                $builder, $keys
+            )->filter(function ($model) use ($keys) {
+                return in_array($model->getScoutKey(), $keys);
+            });
     }
 
     /**
@@ -238,6 +232,19 @@ class ElasticsearchEngine extends Engine
     public function getTotalCount($results)
     {
         return $results['hits']['total'];
+    }
+
+    /**
+     * Flush all of the model's records from the engine.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function flush($model)
+    {
+        $model->newQuery()
+            ->orderBy($model->getKeyName())
+            ->unsearchable();
     }
 
     /**

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -114,7 +114,8 @@ class ElasticsearchEngineTest extends PHPUnit_Framework_TestCase
 
         $model = Mockery::mock('Illuminate\Database\Eloquent\Model');
         $model->shouldReceive('getScoutKey')->andReturn('1');
-        $model->shouldReceive('getScoutModelsByIds')->once()->with($builder, ['1'])->andReturn(Collection::make([$model]));
+        $model->shouldReceive('getScoutModelsByIds')->once()->with($builder, ['1'])->andReturn($models = Collection::make([$model]));
+        $model->shouldReceive('newCollection')->andReturn($models);
 
         $results = $engine->map($builder, [
             'hits' => [


### PR DESCRIPTION
This PR copies functional of these PRs from original laravel-scout:

- Use Model collection where appropriate ([#334](https://github.com/laravel/scout/pull/334))
- Flush records of a model using the engine. **This removes the emitting of the `ModelsFlushed` event.** ([#310](https://github.com/laravel/scout/pull/310))

These changes are allowing use Laravel Scout v6.0 and v7.0.