### PR TITLE
optimize mapping records in retrieving results

### DIFF
--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -231,7 +231,7 @@ class ElasticsearchEngine extends Engine
      * @param  \Laravel\Scout\Builder  $builder
      * @param  mixed  $results
      * @param  \Illuminate\Database\Eloquent\Model  $model
-     * @return Collection
+     * @return \Illuminate\Support\Collection
      */
     public function map(Builder $builder, $results, $model)
     {
@@ -243,10 +243,9 @@ class ElasticsearchEngine extends Engine
 
         $modelIdPositions = array_flip($keys);
 
-        return $model->getScoutModelsByIds(
-            $builder,
-            $keys
-        )->filter(function ($model) use ($keys) {
+        return collect($results['hits']['hits'])->map(function ($result) use ($model) {
+            return new $model($result['_source']);
+        })->filter(function ($model) use ($keys) {
             return in_array($model->getScoutKey(), $keys);
         })->sortBy(function ($model) use ($modelIdPositions) {
             return $modelIdPositions[$model->getScoutKey()];


### PR DESCRIPTION
In order to improve search performance and prevent queries to the database while fetching data, we can hydrate the model in a different way.
Also with this approach, we can persist data only into the elastic index and retrieve it without performing queries in database, if we just add this method in our model:
```
protected function create(array $attributes = [])
{
    return tap($this->newModelInstance($attributes), function ($model) {
        static::$dispatcher->dispatch("eloquent.saved: ".static::class, $model);
    });
}
```