### PR TITLE
JakobOnline hits fix

### DIFF
--- a/src/Engines/ElasticsearchEngine.php
+++ b/src/Engines/ElasticsearchEngine.php
@@ -134,15 +134,15 @@ class ElasticsearchEngine extends Engine
      */
     public function paginate(Builder $builder, $perPage, $page)
     {
-        $result = $this->performSearch($builder, [
+        $results = $this->performSearch($builder, [
             'numericFilters' => $this->filters($builder),
             'from' => (($page * $perPage) - $perPage),
             'size' => $perPage,
         ]);
 
-        $result['nbPages'] = $result['hits']['total'] / $perPage;
+        $results['nbPages'] = $this->getTotalCount($results) / $perPage;
 
-        return $result;
+        return $results;
     }
 
     /**
@@ -235,7 +235,7 @@ class ElasticsearchEngine extends Engine
      */
     public function map(Builder $builder, $results, $model)
     {
-        if ($results['hits']['total'] === 0) {
+        if ($this->getTotalCount($results) === 0) {
             return $model->newCollection();
         }
 
@@ -261,7 +261,11 @@ class ElasticsearchEngine extends Engine
      */
     public function getTotalCount($results)
     {
-        return $results['hits']['total'];
+        if(is_numeric($results['hits']['total'])){
+            return $results['hits']['total'];
+        } else {
+            return $results['hits']['total']['value'];
+        }
     }
 
     /**

--- a/tests/ElasticsearchEngineTest.php
+++ b/tests/ElasticsearchEngineTest.php
@@ -154,7 +154,7 @@ class ElasticsearchEngineTest extends TestCase
         /** @var Builder|MockInterface $builder */
         $builder = Mockery::mock(Builder::class);
 
-        /** @var Model|MockInterface $model */
+        /** @var Model|MockInterface $secondModel */
         $secondModel = Mockery::mock(Model::class);
         $secondModel->shouldReceive('getScoutKey')->andReturn('2');
 
@@ -179,5 +179,41 @@ class ElasticsearchEngineTest extends TestCase
         ], $model);
         $this->assertEquals($secondModel, $results[0]);
         $this->assertEquals($model, $results[1]);
+    }
+
+    public function test_creates_paginate_object_with_total_as_integer(){
+        
+        $total = 42;
+        $pages = 3;
+
+        /** @var Client|MockInterface $client */
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('search')->andReturn(['hits' => ['total'=> $total]]);
+
+        /** @var Builder|MockInterface $builder */
+        $builder = Mockery::mock(Builder::class);
+        $builder->model = new SearchableModel;
+
+        $engine = new ElasticsearchEngine($client);
+        $results = $engine->paginate($builder, $total/$pages, 0); 
+        $this->assertEquals($pages, $results['nbPages']);
+    }
+
+    public function test_creates_paginate_object_with_total_as_object(){
+        
+        $total = 42;
+        $pages = 3;
+
+        /** @var Client|MockInterface $client */
+        $client = Mockery::mock(Client::class);
+        $client->shouldReceive('search')->andReturn(['hits' => ['total'=>['value' => $total]]]);
+
+        /** @var Builder|MockInterface $builder */
+        $builder = Mockery::mock(Builder::class);
+        $builder->model = new SearchableModel;
+
+        $engine = new ElasticsearchEngine($client);
+        $results = $engine->paginate($builder, $total/$pages, 0); 
+        $this->assertEquals($pages, $results['nbPages']);
     }
 }


### PR DESCRIPTION
Since original PR was not merged, Im opening a new one. 

Issue is with ES 7.17, hits is array
```
  "hits" : {
    "total" : {
      "value" : 10000,
      "relation" : "gte"
    },
```